### PR TITLE
Fix path to httpd configuration in lab

### DIFF
--- a/src/assets/downloads/u16/u16_lab.txt
+++ b/src/assets/downloads/u16/u16_lab.txt
@@ -30,7 +30,7 @@ Web server must respond on port 80.
     Answer: `ss -ntulp` will show port 80.
 
 The server is currently set on 8087 and needs to be fixed
-in /etc/httpd/conf/http.conf. The “Listen 8087” line must be changed to “Listen 80” and the
+in /etc/httpd/conf/httpd.conf. The “Listen 8087” line must be changed to “Listen 80” and the
 service restarted `systemctl restart httpd`
 
 Ensure that the server can be reached by external connection attempts on port 80.


### PR DESCRIPTION
## Summary
- correct typo in the httpd config path for Unit 16 lab instructions

## Testing
- `bash scripts/generate_resources.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861851556448329bb99c159049b5031